### PR TITLE
fix: フラッシュメッセージのスタイルが適用されない問題を修正

### DIFF
--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -42,5 +42,10 @@ module.exports = {
     // require('@tailwindcss/forms'),
     // require('@tailwindcss/typography'),
     // require('@tailwindcss/container-queries'),
-  ]
+  ],
+  safelist: [
+    "alert-warning",
+    "alert-success",
+    "alert-danger"
+  ],
 }


### PR DESCRIPTION
フラッシュメッセージのスタイルが適用されてなかったので修正

### 状況
ローカル上でフラッシュメッセージを表示させた時にスタイルが適用されなかった（この時確認してたのはwarningのフラッシュ）。
開発モードのソースには`alert-warning`が生成されていたが、Elementタブには認識されていなかった。
`class="alert alert-<%= flash_type(message_type) %>"`の部分を一時的に`class="alert alert-warning"`に変更→問題なくスタイルがあったていた。Elementタブにも認識されていた。
この後に再びコードを`class="alert alert-<%= flash_type(message_type) %>"`に戻したところ、問題なくスタイルが反映された。
`alert-warning`が生成されており、Elementタブにも`alert-warning`が認識されていた。
反映されたので本番環境にpushしたところ、本番環境でも上記の問題が発生。
再びローカルの開発モードで確認したところ、問題が再発。

### 対応
誤字かと思ったが自分で見つけられなかったので、chatGPTに質問。
 JIT（Just-In-Time）モードやsafelistについて指摘されたので、調査　→　[Tailwind CSSの嬉しいけど嬉しくない機能 - Just In Time Mode](https://zenn.dev/maronn/articles/f66768982a2082)
safelistに各フラッシュのスタイルを登録してローカル上で確認　→　問題なく期待通りのフラッシュが生成されたのを確認。