### PR TITLE
fix: review.rbの誤字を修正

### DIFF
--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -5,5 +5,5 @@ class Review < ApplicationRecord
   validates :pen, length: { maximum: 50 }
 
   belongs_to :user
-  belong_to :product
+  belongs_to :product
 end


### PR DESCRIPTION
### ### flyにデプロイしたアプリにアクセスすると503エラーになる

- 昨日までは問題なくアクセスできていた。
- 今日やったのは各種モデル（brands、products、reviews）の作成・編集、各マイグレーションファイルの編集・マイグレーション、各コントローラの編集、ルーティングの設定
- 各段階での自動デプロイもすべてグリーン。特に問題なさそう。
- ダッシュボードのStatusページにはLHRリージョンでの障害情報のみ

ログ
```
nrt [error] [PC01] instance refused connection. is your app listening on 0.0.0.0:3000? make sure it is not only listening on 127.0.0.1 (hint: look at your startup logs, servers often print the address they are listening on)

nrt [error] [PR01] no known healthy instances found for route tcp/443. (hint: is your app shut down? is there an ongoing deployment with a volume or are you using the 'immediate' strategy? have your app's instances all reached their hard limit?)

nrt [error] [PR01] no known healthy instances found for route tcp/443. (hint: is your app shut down? is there an ongoing deployment with a volume or are you using the 'immediate' strategy? have your app's instances all reached their hard limit?)
nrt [error] [PR01] no known healthy instances found for route tcp/443. (hint: is your app shut down? is there an ongoing deployment with a volume or are you using the 'immediate' strategy? have your app's instances all reached their hard limit?)
...
nrt [info] /usr/local/bundle/ruby/3.3.0/gems/activerecord-7.2.2.1/lib/active_record/dynamic_matchers.rb:22:in `method_missing': undefined method `belong_to' for class Review (NoMethodError)
nrt [info] Did you mean? belongs_
```

[flyのコミュニティにあった類似の質問](https://community.fly.io/t/error-instance-refused-connection/13013)を読んだら、サーバーが起動しなかったということらしいので、`NoMethodError`になっている部分を修正