### PR TITLE
インク登録画面（モーダル）作成

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,9 +1,34 @@
 class ProductsController < ApplicationController
   def index
-    @Products = Product.includes(:brand).all
+    @products = Product.includes(:brand).all
   end
 
   def show
     @product = Product.find_by(params[:id])
+  end
+
+  def new
+    @product = Product.new
+  end
+
+  def create
+    @product = Product.new(product_params)
+    brand_name = params[:product][:brand_name]
+    brand = Brand.find_or_create_by!(name: brand_name)
+    @product.brand_id = brand.id
+
+    if @product.save
+      flash[:notice] = t('product.new.notice')
+      redirect_to products_path
+    else
+      flash.now[:alert] = t('product.new.alert')
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def product_params
+    params.require(:product).permit(:name, :brand_id, :category_id)
   end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,6 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import RemoteModalController from "./remote_modal_controller"
+application.register("remote-modal", RemoteModalController)

--- a/app/javascript/controllers/remote_modal_controller.js
+++ b/app/javascript/controllers/remote_modal_controller.js
@@ -1,0 +1,8 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="remote-modal"
+export default class extends Controller {
+  connect() {
+    this.element.showModal()
+  }
+}

--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -1,5 +1,7 @@
 class Brand < ApplicationRecord
   validates :name, presence: true
+  validates :official_url, format: { with: /\A[a-zA-Z]+\z/, message: "不正なURLです" }, allow_blank: true
+  validates :official_shopping_url, format: { with: /\A[a-zA-Z]+\z/, message: "不正なURLです" }, allow_blank: true
 
   has_many :products
 end

--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -1,7 +1,5 @@
 class Brand < ApplicationRecord
   validates :name, presence: true
-  validates :official_url, format: { with: /\A[a-zA-Z]+\z/, message: "不正なURLです" }
-  validates :official_shopping_url, format: { with: /\A[a-zA-Z]+\z/, message: "不正なURLです" }
 
   has_many :products
 end

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -1,0 +1,21 @@
+<%= form_with(model: product, class: "w-full max-w-lg") do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
+  <div class="flex flex-wrap -mx-3 mb-4">
+    <div class="w-full px-3">
+      <%= f.label :name, class: "px-3" %>
+      <%= f.text_field :name, class: "input input-bordered form-control w-full mx-auto pl-2 text-base" %>
+    </div>
+  </div>
+  <div class="flex flex-wrap -mx-3 mb-4">
+    <div class="w-full px-3">
+      <%= f.label :brand_name, class: "px-3" %>
+      <%= f.text_field :brand_name, class: "input input-bordered form-control w-full mx-auto pl-2 text-base" %>
+    </div>
+  </div>
+  <div class="flex flex-wrap -mx-3 mb-4">
+    <div class="w-full px-3">
+      <%= f.collection_select(:category_id, Category.all, :id, :color, {include_blank: "色系統を選択"}, {class: "select select-bordered w-40 max-w-xs"}) %>
+    </div>
+  </div>
+  <%= f.submit nil, class: "btn btn-secondary w-full mx-auto mt-2" %>
+<% end %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -1,4 +1,13 @@
-<div>
-  <h1 class="font-bold text-4xl">Products#index</h1>
-  <p>Find me in app/views/products/index.html.erb</p>
-</div>
+<%= render "shared/remote_modal", title: "インクを探す" do %>
+  <div class="container mx-auto w-[540px] px-10 py-5">
+    <% if @products.present? %>
+      <% @products.each do |product| %>
+        <%= product.name %>
+        <%= product.brand.name %>
+        <%= product.category.color %>
+      <% end %>
+    <% else %>
+      インクが登録されていません
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -1,4 +1,5 @@
-<div>
-  <h1 class="font-bold text-4xl">Products#new</h1>
-  <p>Find me in app/views/products/new.html.erb</p>
-</div>
+<%= render "shared/remote_modal", title: t('product.new.title') do %>
+  <div class="container mx-auto w-[540px] px-10 py-5">
+    <%= render 'form', product: @product %>
+  </div>
+<% end %>

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -18,7 +18,7 @@
       <%= text_field_tag :product_name, @review.product&.name, class: "input input-bordered form-control mb-2 w-full mx-auto pl-2 text-base" %>
     </div>
     <div class="w-full px-3">
-      <%= link_to t('reviews.new.select_product'), "#", class: "btn btn-primary w-full mx-auto" %>
+      <%= link_to t('reviews.new.select_product'), new_product_path, class: "btn btn-primary w-full mx-auto", data: { turbo_frame: 'remote_modal' } %>
     </div>
   </div>
   <div class="flex flex-wrap -mx-3 mb-4">
@@ -33,3 +33,4 @@
   </div>
   <%= f.submit nil, class: "btn btn-secondary w-full mx-auto mt-2" %>
 <% end %>
+<%= turbo_frame_tag "remote_modal" %>

--- a/app/views/shared/_remote_modal.html.erb
+++ b/app/views/shared/_remote_modal.html.erb
@@ -1,0 +1,16 @@
+<%= turbo_frame_tag 'remote_modal' do %>
+  <dialog id="contact_form_modal" aria-labelledby="modal_title" class="modal" data-controller="remote-modal">
+    <div class="modal-box w-11/12 max-w-5xl">
+      <form method="dialog">
+        <%= button_to "✕", nil, class: "btn btn-sm btn-circle btn-ghost absolute right-2 top-2" %>
+      </form>
+      <div class="border-b-2 border-gray-200">
+        <h3 class="text-lg font-bold"><%= title %></h3>
+      </div>
+      <div class="">
+        <%= render 'shared/flash_message' %>
+        <%= yield %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -15,3 +15,6 @@ ja:
         product_name: インク
         paper: 使用した紙
         pen: 使用したペン
+      product:
+        name: インクの名前
+        brand_name: メーカー名

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,9 +1,14 @@
 ja:
   helpers:
     submit:
-      create: 投稿する
-      submit: 保存
-      update: 更新
+      reviews:
+        create: 投稿する
+        submit: 保存する
+        update: 更新する
+      products:
+        create: 登録する
+        submit: 保存する
+        update: 更新する
     label:
       email: メールアドレス
       password: パスワード
@@ -22,3 +27,8 @@ ja:
   reviews:
     new:
       select_product: インクを選択
+  product:
+    new:
+      title: インクを登録する
+      notice: インクを登録しました
+      alert: インクの登録に失敗しました

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users, controllers: { registrations: 'users/registrations' }
   resources :users, only: :show
 
-  resources :products, only: %i[index show]
+  resources :products, only: %i[index show new create]
   resources :reviews, only: %i[index show new create]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 


### PR DESCRIPTION
 #32 インク登録画面（モーダル）作成

- [x] `docker compose exec web rails generate stimulus remote_modal`を実行
- [x] app/javascript/controllers/remote_modal_controllers.jsを編集
- [x] app/views/shared/_remote_modal.html.erbを作成・編集
- [x] app/views/products/new.html.erbを編集
- [x] app/controllers/products_controller.rbを編集
- [x] app/models/products.rbを編集
- [x] i18nで日本語化

- brandモデルのofficial_urlとofficial_shopping_urlにバリデーションかけるとバリデーションエラーが出て新規作成のbrandを保存できないのでいったん削除しましたが、`allow_blank: true`オプションを付ければいいだけだったので復活させました。
official_urlとofficial_shopping_urlはadminユーザのみ編集できるようにする予定です。
- ページ遷移の確認等のため、index.html.erbを仮で編集しています。 #31 で整えます。