### PR TITLE
fix:Swiperの読み込みが不安定だったのでCDNの記述位置を変更

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css"/>
     <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -48,7 +48,6 @@
   </div>
 </section>
 
-<script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
 <script>
   var swiper = new Swiper(".mySwiper", {
     loop: true,


### PR DESCRIPTION
### 状況
本番環境でたまにUncaught ReferenceError: Swiper is not definedが出る。
ページを更新したら直る。

### 対応
SwiperのJSのCDNを読み込む場所をshow.html.erbからapplication.hrml.erbのheadに変更してみた。
ローカルでは上記の問題は発生していないのを確認。しばらくこれで様子見。