### PR TITLE
マイページから投稿を削除したときは削除後にマイページに遷移するようにする

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -24,6 +24,7 @@ class ReviewsController < ApplicationController
 
   def show
     @review = Review.find(params[:id])
+    session[:referer] = request.referer
   end
 
   def edit
@@ -50,7 +51,11 @@ class ReviewsController < ApplicationController
     review.images.purge if review.images.attached?
     review.destroy!
     flash[:notice] = t('reviews.delete.notice')
-    redirect_to root_path, status: :see_other
+    if session[:referer].include?('users')
+      redirect_to user_path(current_user), status: :see_other
+    else
+      redirect_to root_path, status: :see_other
+    end
   end
 
   def search


### PR DESCRIPTION
 #94 

- [x] app/controllers/reviews_controller.rbを編集

- マイページから投稿詳細へ遷移して投稿を削除したときは削除後にマイページへ遷移するようにしました。