### PR TITLE
ヘッダーに画像やレビューのカードが透けていたのを直した

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,14 +23,14 @@
 
   <body>
     <div class="flex flex-col h-screen">
-      <header class="sticky top-0">
+      <header class="sticky top-0 z-40">
         <%= render 'layouts/header' %>
       </header>
       <main class="flex-grow">
         <%= render 'shared/flash_message' %>
         <%= yield %>
       </main>
-      <footer class="footer bg-[#A6ABBD] text-[#424656] items-center p-4 sticky bottom-0">
+      <footer class="footer bg-[#A6ABBD] text-[#424656] items-center p-4 sticky bottom-0 z-40">
         <%= render 'layouts/footer' %>
       </footer>
     </div>


### PR DESCRIPTION
 #95 

- [x] app/views/layouts/application.html.erbを編集

- スクロールするとヘッダーの上にレビューのカードや画像が表示されてしまっていたのを修正しました。