### PR TITLE
インクの名前が長いと表示が崩れていたのを修正

### DIFF
--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,6 +1,6 @@
 <section class="text-gray-600 body-font">
   <div class="container px-5 py-24 mx-auto">
-    <div class="flex flex-wrap w-1/2 justify-center mx-auto mb-20 rounded-lg border border-gray-400 p-8 gap-10">
+    <div class="flex w-1/2 justify-center mx-auto mb-20 rounded-lg border border-gray-400 p-8 gap-10">
       <div class="flex flex-col gap-2">
         <h1 class="text-black text-3xl font-bold"><%= @product.name %></h1>
         <p><%= @product.brand.name %></p>


### PR DESCRIPTION
 #102 

- [x] app/views/products/show.html.erb

- インクの名前が長いと公式へのリンクボタンが回り込んでしまっていたのを修正