### PR TITLE
プロフィール編集機能作成

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :account])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :account])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :account, :body, :x_account, :instagram_account, :youtube_account])
   end
 
   def redirect_root

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :account])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :account, :body, :x_account, :instagram_account, :youtube_account])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :account, :body, :x_account, :instagram_account, :youtube_account, :avatar])
   end
 
   def redirect_root

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -38,7 +38,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
-  # protected
+  protected
+
+  def update_resource(resource, params)
+    resource.update_without_password(params)
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -44,6 +44,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
     resource.update_without_password(params)
   end
 
+  def after_update_path_for(resource)
+    user_path(current_user)
+  end
+
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params
   #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,4 +2,8 @@ module ApplicationHelper
   def post_review_url(review)
     "https://inklog.fly.dev/reviews/#{review.id}"
   end
+
+  def post_profile_url(user)
+    "https://inklog.fly.dev/users/#{user.account}"
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,10 @@ class User < ApplicationRecord
 
   validates :name, presence: true, uniqueness: true, length: { maximum: 10 }
   validates :account, presence: true, uniqueness: true, format: { with: /\A[a-zA-Z0-9]+\z/ }, length: { minimum: 4, maximum: 20 }
+  validates :body, length: { maximum: 500 }
+  validates :x_account, format: { with: /\Ahttps?:\/\/x.com\/[^\n]+\z/ , message: "のURLを入力してください" }, allow_blank: true
+  validates :instagram_account, format: { with: /\Ahttps?:\/\/www.instagram.com\/[^\n]+\z/ , message: "のURLを入力してください" }, allow_blank: true
+  validates :youtube_account, format: { with: /\Ahttps?:\/\/youtube.com\/[^\n]+\z/ , message: "のURLを入力してください" }, allow_blank: true
 
   has_many :reviews
   has_one_attached :avatar

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="container mx-auto w-[540px] px-10 py-5">
-  <h1 class="text-5xl font-bold text-center mb-10">プロフィール編集</h1>
+  <h1 class="text-5xl font-bold text-center mb-10"><%= t('users.edit.title') %></h1>
 
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
     <%= render "devise/shared/error_messages", resource: resource %>
@@ -14,7 +14,7 @@
     </div>
     <div class="field">
       <%= f.label :body %><br />
-      <%= f.text_area :body, autofocus: true, autocomplete: "body", class: "textarea textarea-bordered textarea-lg resize-none form-control h-[200px] w-full mx-auto pl-2 pt-1 text-base mb-6", placeholder: "500文字以内" %>
+      <%= f.text_area :body, autofocus: true, autocomplete: "body", class: "textarea textarea-bordered textarea-lg resize-none form-control h-[200px] w-full mx-auto pl-2 pt-1 text-base mb-6", placeholder: t('users.edit.body_length') %>
     </div>
     <div class="field">
       <%= f.label :avatar %><br />
@@ -27,15 +27,15 @@
     </div>
     <div class="field">
       <%= f.label :x_account %><br />
-      <%= f.text_field :x_account, autofocus: true, autocomplete: "name", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2" %>
+      <%= f.text_field :x_account, autofocus: true, autocomplete: "name", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: t('users.edit.x_account_url') %>
     </div>
     <div class="field">
       <%= f.label :instagram_account %><br />
-      <%= f.text_field :instagram_account, autofocus: true, autocomplete: "name", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2" %>
+      <%= f.text_field :instagram_account, autofocus: true, autocomplete: "name", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: t('users.edit.instagram_account_url') %>
     </div>
     <div class="field">
       <%= f.label :youtube_account %><br />
-      <%= f.text_field :youtube_account, autofocus: true, autocomplete: "name", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2" %>
+      <%= f.text_field :youtube_account, autofocus: true, autocomplete: "name", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: t('users.edit.youtube_account_url') %>
     </div>
 
     <!-- パスワードとメールアドレスの変更。別ページ作成

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,43 +1,83 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<div class="container mx-auto w-[540px] px-10 py-5">
+  <h1 class="text-5xl font-bold text-center mb-10">プロフィール編集</h1>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+    <div class="field">
+      <%= f.label :account %><br />
+      <%= f.text_field :account, autofocus: true, autocomplete: "account", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: t('devise.registrations.new.account_validate') %>
+    </div>
+    <div class="field">
+      <%= f.label :name %><br />
+      <%= f.text_field :name, autofocus: true, autocomplete: "name", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2", placeholder: t('devise.registrations.new.maximum_name_length') %>
+    </div>
+    <div class="field">
+      <%= f.label :body %><br />
+      <%= f.text_area :body, autofocus: true, autocomplete: "body", class: "textarea textarea-bordered textarea-lg resize-none form-control h-[200px] w-full mx-auto pl-2 pt-1 text-base mb-6", placeholder: "500文字以内" %>
+    </div>
+    <div class="field">
+      <%= f.label :avatar %><br />
+      <%= f.file_field :avatar, class: "file-input file-input-bordered form-control mb-6 w-full mx-auto mt-2" %>
+      <% if @user.avatar.attached? %>
+        <div class="flex items-center justify-center">
+          <%= image_tag @user.avatar, class: "w-12 rounded-full" %>
+        </div>
+      <% end %>
+    </div>
+    <div class="field">
+      <%= f.label :x_account %><br />
+      <%= f.text_field :x_account, autofocus: true, autocomplete: "name", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2" %>
+    </div>
+    <div class="field">
+      <%= f.label :instagram_account %><br />
+      <%= f.text_field :instagram_account, autofocus: true, autocomplete: "name", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2" %>
+    </div>
+    <div class="field">
+      <%= f.label :youtube_account %><br />
+      <%= f.text_field :youtube_account, autofocus: true, autocomplete: "name", class: "input input-bordered form-control mb-6 w-full mx-auto mt-2" %>
+    </div>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+    <!-- パスワードとメールアドレスの変更。別ページ作成
+    <div class="field">
+      <%= f.label :email %><br />
+      <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    </div>
+
+    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+      <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+    <% end %>
+
+    <div class="field">
+      <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+      <%= f.password_field :password, autocomplete: "new-password" %>
+      <% if @minimum_password_length %>
+        <br />
+        <em><%= @minimum_password_length %> characters minimum</em>
+      <% end %>
+    </div>
+
+    <div class="field">
+      <%= f.label :password_confirmation %><br />
+      <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    </div>
+
+    <div class="field">
+      <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+      <%= f.password_field :current_password, autocomplete: "current-password" %>
+    </div>
+    -->
+    <div class="actions">
+      <%= f.submit nil, class: "btn btn-secondary mb-6 w-full mx-auto mt-2" %>
+    </div>
   <% end %>
 
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
-    <% end %>
+  <!-- アカウント削除。別ページで使用
+  <h3>Cancel my account</h3>
+
+  <div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
+  -->
+  <div class="flex items-center justify-center">
+    <%= link_to t('helpers.links.back'), 'javascript:history.back()', class: "btn btn-outline btn-primary" %>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>
+</div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -19,8 +19,12 @@
         <details class="dropdown dropdown-end">
           <summary class="btn btn-ghost m-1">
             <div class="avatar">
-              <div class="w-12 rounded-full">
-                <%= image_tag 'kkrn_icon_user_1.png' %>
+              <div class="w-12 rounded-full border-[2px] border-gray-200">
+                <% if current_user.avatar.attached? %>
+                  <%= image_tag current_user.avatar %>
+                <% else %>
+                  <%= image_tag 'kkrn_icon_user_1.png' %>
+                <% end %>
               </div>
             </div>
             <%= current_user.name %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
       <header class="sticky top-0 z-40">
         <%= render 'layouts/header' %>
       </header>
-      <main class="flex-grow">
+      <main class="flex-grow text-[#333333] body-font">
         <%= render 'shared/flash_message' %>
         <%= yield %>
       </main>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,8 +1,8 @@
-<section class="text-gray-600 body-font">
+<section class="overflow-hidden">
   <div class="container px-5 py-24 mx-auto">
     <div class="flex w-1/2 justify-center mx-auto mb-20 rounded-lg border border-gray-400 p-8 gap-10">
       <div class="flex flex-col gap-2">
-        <h1 class="text-black text-3xl font-bold"><%= @product.name %></h1>
+        <h1 class="text-3xl font-bold"><%= @product.name %></h1>
         <p><%= @product.brand.name %></p>
         <p><%= @product.category.color %><%= t('product.show.color') %></p>
       </div>

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -11,23 +11,31 @@
       </div>
     <% end %>
     <div class="card-actions justify-end mt-1">
-    <!-- いいね・ブックマーク・Xシェア機能実装後に使う部分
+    <!-- いいね・ブックマーク機能実装後に使う部分
       <i class="fa-regular fa-heart"></i>
       <i class="fa-regular fa-bookmark"></i>
       <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-size="large" data-hashtags="インク沼" data-lang="ja" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
     -->
-      <%= link_to "https://twitter.com/share?url=#{post_review_url(review)}&text=#{review.product.brand.name}%20#{review.product.name}をレビュー！%0a%0a#{review.title}&hashtags=インク沼", title: "Xでシェア" do %>
+      <%= link_to "https://twitter.com/share?url=#{post_review_url(review)}&text=#{review.product.brand.name}%20#{review.product.name}をレビュー！%0a%0a%23インク沼%20%23INKLOG%0a", title: "Xでシェア" do %>
         <i class="fa-brands fa-square-x-twitter text-[24px]"></i>
       <% end %>
     </div>
   </div>
   <div class="card-body gap-0 flex-shrink-0 w-[340px] p-4">
-    <h2 class="card-title overflow-hidden mb-1 text-lg font-bold text-ellipsis whitespace-nowrap"><%= review.title %></h2>
+    <div class="card-title overflow-hidden mb-1 justify-between">
+      <span class="w-3/4 text-[24px] font-bold text-ellipsis line-clamp-1"><%= review.title %></span>
+      <div class="w-8 rounded-full border-[2px] border-gray-200">
+        <% if review.user.avatar.attached? %>
+          <%= image_tag review.user.avatar %>
+        <% else %>
+          <%= image_tag 'kkrn_icon_user_1.png' %>
+        <% end %>
+      </div>
+    </div>
     <div class="text-sm"><%= review.product.name %></div>
     <div class="text-sm"><%= review.product.brand.name %></div>
     <div Class="overflow-hidden my-2 text-ellipsis line-clamp-3 whitespace-pre-wrap h-[72px]"><%= review.body %></div>
-    <div class="text-xs text-[#959595]"><%= review.paper %></div>
-    <div class="text-xs text-[#959595]"><%= review.pen %></div>
+    <div class="text-xs text-[#959595]"><%= review.paper %>　<%= review.pen %></div>
     <div class="card-actions justify-end">
       <%= link_to t('reviews.index.show_review'), review_path(review), class: "btn btn-sm btn-primary" %>
     </div>

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -1,4 +1,4 @@
-<section class="text-gray-600 body-font overflow-hidden">
+<section class="overflow-hidden">
   <div class="container px-5 py-10 mx-auto">
     <div class="lg:w-4/5 mx-auto flex flex-wrap">
       <div class="flex flex-col lg:w-1/2">

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -33,10 +33,16 @@
       <div class="lg:w-1/2 w-full lg:pl-10 lg:py-6 mt-6 lg:mt-0">
         <h1 class="text-gray-900 text-3xl title-font font-medium mb-1"><%= @review.title %></h1>
         <div class="flex mb-4">
-          <div class="flex items-center">
-            <%= image_tag "kkrn_icon_user_1.png", class: "w-12 rounded-full" %>
-            <%= link_to @review.user.name, "#" %>
-          </div>
+          <%= link_to user_path(@review.user), class: "flex items-center gap-2" do %>
+            <div class="w-10 rounded-full border-[2px] border-gray-200">
+              <% if @review.user.avatar.attached? %>
+                <%= image_tag @review.user.avatar %>
+              <% else %>
+                <%= image_tag 'kkrn_icon_user_1.png' %>
+              <% end %>
+            </div>
+            <p><%= @review.user.name %></p>
+          <% end %>
           <div class="flex ml-auto items-center justify-center text-[#959595]"><%= l(@review.created_at) %></div>
         </div>
         <p class="leading-relaxed whitespace-pre-wrap"><%= @review.body %></p>

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -25,7 +25,7 @@
           </div>
         <% end %>
         <div class="mt-5 mx-auto">
-          <%= link_to "https://twitter.com/share?url=#{post_review_url(@review)}&text=#{@review.product.brand.name}%20#{@review.product.name}をレビュー！%0a%0a#{@review.title}&hashtags=インク沼", title: "Xでシェア", class: "btn btn-neutral gap-0 w-[350px]" do %>
+          <%= link_to "https://twitter.com/share?url=#{post_review_url(@review)}&text=#{@review.product.brand.name}%20#{@review.product.name}をレビュー！%0a%0a%23インク沼%20%23INKLOG%0a", title: "Xでシェア", class: "btn btn-neutral gap-0 w-[350px]" do %>
             <i class="fa-brands fa-x-twitter text-[24px]"></i></i><span class="text-[20px]">でシェア</span>
           <% end %>
         </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,13 +1,43 @@
-<div class="container mx-auto w-full px-10 py-10">
-  <div class="flex justify-center items-center gap-10 my-2">
-    <div>
-      <div class="bg-white w-[150px] rounded-full mx-10"><%= image_tag 'kkrn_icon_user_1.png' %> </div>
+<section class="text-gray-600 body-font overflow-hidden">
+  <div class="container px-5 py-10 mx-auto">
+    <% if current_user == @user %>
+      <div class="flex justify-end">
+        <%= link_to "プロフィールの編集", edit_user_registration_path, class: "btn btn-accent" %>
+      </div>
+    <% end %>
+    <div class="lg:w-4/5 mx-auto flex flex-wrap items-center justify-center">
+      <div class="items-center">
+        <% if @user.avatar.attached? %>
+          <div class="bg-white w-[150px] rounded-full mx-10 border-[2px] border-gray-200"><%= image_tag @user.avatar %></div>
+        <% else %>
+          <div class="bg-white w-[150px] rounded-full mx-10 border-[2px] border-gray-200"><%= image_tag 'kkrn_icon_user_1.png' %></div>
+        <% end %>
+      </div>
+      <div class="mx-10 flex flex-col">
+        <span class="text-[36px] text-center"><%= @user.name %></span>
+        <!-- フォローフォロワー機能実装誤に使用
+        <div>0フォロー　0フォロワー</div>
+        -->
+        <div><%= @user.body %></div>
+        <div class="flex items-center gap-4">
+          <% if @user.x_account.present? %>
+            <%= link_to @user.x_account do %>
+              <i class="fa-brands fa-square-x-twitter text-[24px]"></i>
+            <% end %>
+          <% end %>
+          <% if @user.instagram_account.present? %>
+            <%= link_to @user.instagram_account do %>
+              <i class="fa-brands fa-instagram text-[24px]"></i>
+            <% end %>
+          <% end %>
+          <% if @user.youtube_account.present? %>
+            <%= link_to @user.youtube_account do %>
+              <i class="fa-brands fa-youtube text-[24px]"></i>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
     </div>
-    <div>
-      <p class="text-[36px] mx-10"><%= current_user.name %></p>
-    </div>
-  </div>
-  <div>
     <div class="w-full mx-auto">
       <p class="text-[36px] mx-10 text-center"><%= t('users.show.current_user_reviews') %></p>
     </div>
@@ -18,4 +48,4 @@
       <div><%= t('users.show.review_not_found') %></div>
     <% end %>
   </div>
-</div>
+</section>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,4 @@
-<section class="text-gray-600 body-font overflow-hidden">
+<section class="overflow-hidden">
   <div class="container px-5 py-10 mx-auto">
     <% if current_user == @user %>
       <div class="flex justify-end">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,7 +2,7 @@
   <div class="container px-5 py-10 mx-auto">
     <% if current_user == @user %>
       <div class="flex justify-end">
-        <%= link_to "プロフィールの編集", edit_user_registration_path, class: "btn btn-accent" %>
+        <%= link_to t('users.show.edit_profile'), edit_user_registration_path, class: "btn btn-accent" %>
       </div>
     <% end %>
     <div class="lg:w-4/5 mx-auto flex flex-wrap items-center justify-center">
@@ -18,8 +18,8 @@
         <!-- フォローフォロワー機能実装誤に使用
         <div>0フォロー　0フォロワー</div>
         -->
-        <div><%= @user.body %></div>
-        <div class="flex items-center gap-4">
+        <p><%= @user.body %></p>
+        <div class="flex items-center gap-4 mt-6">
           <% if @user.x_account.present? %>
             <%= link_to @user.x_account do %>
               <i class="fa-brands fa-square-x-twitter text-[24px]"></i>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,12 +6,17 @@
       </div>
     <% end %>
     <div class="lg:w-4/5 mx-auto flex flex-wrap items-center justify-center">
-      <div class="items-center">
+      <div class="flex flex-col">
         <% if @user.avatar.attached? %>
           <div class="bg-white w-[150px] rounded-full mx-10 border-[2px] border-gray-200"><%= image_tag @user.avatar %></div>
         <% else %>
           <div class="bg-white w-[150px] rounded-full mx-10 border-[2px] border-gray-200"><%= image_tag 'kkrn_icon_user_1.png' %></div>
         <% end %>
+        <div class="mt-5 mx-auto items-center justify-center">
+          <%= link_to "https://twitter.com/share?url=#{post_profile_url(@user)}&text=#{@user.name}さんのプロフィール%0a%0a%23インク沼%20%23INKLOG", title: "Xでシェア", class: "btn btn-neutral gap-0 w-[110px]" do %>
+            <i class="fa-brands fa-x-twitter text-[16px]"></i></i><span class="text-[16px]">でシェア</span>
+          <% end %>
+        </div>
       </div>
       <div class="mx-10 flex flex-col">
         <span class="text-[36px] text-center"><%= @user.name %></span>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -23,7 +23,7 @@
         <!-- フォローフォロワー機能実装誤に使用
         <div>0フォロー　0フォロワー</div>
         -->
-        <p><%= @user.body %></p>
+        <p class="whitespace-pre-wrap"><%= @user.body %></p>
         <div class="flex items-center gap-4 mt-6">
           <% if @user.x_account.present? %>
             <%= link_to @user.x_account do %>
@@ -43,7 +43,7 @@
         </div>
       </div>
     </div>
-    <div class="w-full mx-auto">
+    <div class="w-full mx-auto mt-5">
       <p class="text-[36px] mx-10 text-center"><%= t('users.show.current_user_reviews') %></p>
     </div>
     <div class="flex flex-wrap justify-center items-center p-5 gap-5">

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -12,6 +12,11 @@ ja:
         account: ユーザーID
         password: パスワード
         password_confirmation: パスワード確認
+        body: プロフィール文
+        x_account: Xアカウント
+        instagram_account: instagramアカウント
+        youtube_account: YouTubeチャンネル
+        avatar: アイコン
       review:
         title: タイトル
         body: 本文

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -9,6 +9,9 @@ ja:
         create: 登録する
         submit: 保存する
         update: 更新する
+      user:
+        create: 登録する
+        update: 更新する
     label:
       email: メールアドレス
       password: パスワード
@@ -40,9 +43,16 @@ ja:
       万年筆・ガラスペン用インクレビューサービス
   users:
     show:
-      title: マイページ
+      title: プロフィール
+      edit_profile: プロフィールを編集
       current_user_reviews: 投稿一覧
       review_not_found: 投稿がありません
+    edit:
+      title: プロフィール編集
+      body_length: 500文字以内
+      x_account_url: https://x.com/sample
+      instagram_account_url: https://www.instagram.com/sample/
+      youtube_account_url: http://youtube.com/@sample
   reviews:
     form:
       select_product: インクを選択

--- a/db/migrate/20250411051947_add_profiles_to_users.rb
+++ b/db/migrate/20250411051947_add_profiles_to_users.rb
@@ -1,0 +1,8 @@
+class AddProfilesToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :body, :string
+    add_column :users, :x_account, :string
+    add_column :users, :instagram_account, :string
+    add_column :users, :youtube_account, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_21_080802) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_11_051947) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -85,6 +85,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_21_080802) do
     t.datetime "updated_at", null: false
     t.string "name", null: false
     t.string "account", null: false
+    t.string "body"
+    t.string "x_account"
+    t.string "instagram_account"
+    t.string "youtube_account"
     t.index ["account"], name: "index_users_on_account", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["name"], name: "index_users_on_name", unique: true


### PR DESCRIPTION
 #18 

- [x] userテーブルに`body`、`x_account`、`instagram_account`、`youtube_account`のカラムを追加
- [x] マイグレーションファイルを編集
- [x] `docker compose exec web rails db:migrate`を実行
- [x] app/controllers/application_controller.rbを編集してプロフィールで編集するカラムの許可を追加
- [x] app/views/devise/registrations/edit.html.erbを編集してプロフィール編集用フォームを作成
- [x] app/views/users/show.html.erbを編集を編集して載せる情報を追加し、編集用ページへのリンクを設置
- [x] app/controllers/users/registrations_controller.rbを編集して、プロフィール編集後のリダイレクトページをマイページに変更するのと、パスワード入力なしでプロフィールの変更をできるようにする記述を追加
- [x] i18nで日本語化

---

今回の実装で #29 で実装予定だったアバター画像についての実装もやってしまったので、#29 では画像の削除機能のみ実装。
以下、今回実装してしまった部分
- [x] app/controllers/application_controller.rbを編集してプロフィール画像用のカラムの編集を許可
- [x] app/models/user.rbを編集して画像添付用の記述を追加
- [x] app/views/users/registrations/edit.html.erbを編集してアバター画像用の項目入力フォームを追加
- [x] app/views/users/show.html.erbを編集してアバター画像が添付されている時に添付された画像を表示するように変更
- [x] app/views/layouts/_header.html.erbを編集してアバター画像が添付されている時に添付された画像を表示するように変更
- [x] app/views/reviews/_review.html.erbを編集してアバター画像が添付されている時に添付された画像を表示するように変更
- [x] app/views/reviews/show.html.erbを編集してアバター画像が添付されている時に添付された画像を表示するように変更

---

- 外部SNSアカウントのバリデーションは、YouTubeチャンネルのURLが3種類ほどあるので、URL全文を入力させることにしました。
- アバター画像のバリデーション書き忘れたので #29 で実装します。
- app/views/devise/registrations/edit.html.erbにもともと記載されていた記述は #119 で使おうと思うのでコメントアウトで残しています。
- 全体の細かいデザイン調整とXシェア時の文章等調整しました。