### PR TITLE
レビューの添付画像とユーザーアイコンの削除機能

### DIFF
--- a/app/controllers/review/attachments_controller.rb
+++ b/app/controllers/review/attachments_controller.rb
@@ -1,0 +1,7 @@
+class Review::AttachmentsController < ApplicationController
+  def destroy
+    image = ActiveStorage::Attachment.find(params[:id])
+    image.purge
+    redirect_to edit_review_path
+  end
+end

--- a/app/controllers/user/attachments_controller.rb
+++ b/app/controllers/user/attachments_controller.rb
@@ -1,0 +1,7 @@
+class User::AttachmentsController < ApplicationController
+  def destroy
+    avatar = ActiveStorage::Attachment.find(params[:id])
+    avatar.purge
+    redirect_to edit_user_registration_path
+  end
+end

--- a/app/helpers/review/attachments_helper.rb
+++ b/app/helpers/review/attachments_helper.rb
@@ -1,0 +1,2 @@
+module Review::AttachmentsHelper
+end

--- a/app/helpers/user/attachments_helper.rb
+++ b/app/helpers/user/attachments_helper.rb
@@ -1,0 +1,2 @@
+module User::AttachmentsHelper
+end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -20,8 +20,11 @@
       <%= f.label :avatar %><br />
       <%= f.file_field :avatar, class: "file-input file-input-bordered form-control mb-6 w-full mx-auto mt-2" %>
       <% if @user.avatar.attached? %>
-        <div class="flex items-center justify-center">
+        <div class="flex flex-col items-center justify-center">
           <%= image_tag @user.avatar, class: "w-12 rounded-full" %>
+          <%=link_to user_attachment_path(@user.id, @user.avatar.id), data: { turbo_method: :delete } do %>
+            <i class="fa-regular fa-circle-xmark"></i>
+          <% end %>
         </div>
       <% end %>
     </div>

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -14,7 +14,12 @@
         <% if @review.images.attached? %>
           <div class="flex mx-2 mt-2 gap-[24px]">
             <% @review.images.each do |image| %>
-              <%= image_tag image, class: "lg:w-[80px] w-full lg:h-[80px] h-64 object-cover object-center" %>
+              <div class ="flex flex-col items-center justify-center">
+                <%= image_tag image, class: "lg:w-[80px] w-full lg:h-[80px] h-64 object-cover object-center" %>
+                <%=link_to review_attachment_path(@review.id, image.id), data: { turbo_method: :delete } do %>
+                  <i class="fa-regular fa-circle-xmark"></i>
+                <% end %>
+              </div>
             <% end %>
           </div>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   end
   resources :reviews, only: %i[index show new create edit update destroy] do
     get :search, on: :collection
+    resources :attachments, controller: "review/attachments", only: :destroy
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@ Rails.application.routes.draw do
   unless defined?(::Rake::SprocketsTask)
     devise_for :users, controllers: { registrations: 'users/registrations' }
   end
-  resources :users, only: :show
+  resources :users, only: :show do
+    resources :attachments, controller: "user/attachments", only: :destroy
+  end
 
   resources :products, only: %i[index show new create] do
     get :search, on: :collection

--- a/test/controllers/review/attachments_controller_test.rb
+++ b/test/controllers/review/attachments_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Review::AttachmentsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/user/attachments_controller_test.rb
+++ b/test/controllers/user/attachments_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class User::AttachmentsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
 #29 （本来はユーザーアイコンを添付できるようにする実装も含んでいたが、 #18 実装中に一緒に実装してしまったので、画像の削除機能のみ実装）

- [x] app/controllers/application_controller.rbを編集してプロフィール画像用のカラムの編集を許可
- [x] app/models/user.rbを編集して画像添付用の記述を追加
- [x] app/views/users/registrations/edit.html.erbを編集して画像用の項目入力フォームを追加
- [x] app/views/users/show.html.erbを編集して画像が添付されている時に添付された画像を表示するように変更
- [x] app/controllers/review/attachment_controller.rbを作成して画像削除用のアクション（destroy）を定義
- [x] app/controllers/user/attachment_controller.rbを作成して画像削除用のアクション（destroy）を定義
- [x] ルーティングを設定する
- [x] app/views/users/registrations/edit.html.erbを編集して添付画像を削除できるようにする
- [x] app/views/reviews/_form.html.erbを編集して添付画像を削除できるようにする

---

- マイページのユーザーアイコンの表示が円形になってなかったのを修正
- avatarのバリデーションを設定。フォームにpngとjpeg形式以外のファイルのアップロードを防ぐ記述と画像がバリデーションに引っ掛かったときにもともと添付されてた画像を表示できるようにする記述を追加