### PR TITLE
ユーザーアイコンのバリデーションを設定

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,15 +4,17 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  has_many :reviews
+  has_one_attached :avatar
+
   validates :name, presence: true, uniqueness: true, length: { maximum: 10 }
   validates :account, presence: true, uniqueness: true, format: { with: /\A[a-zA-Z0-9]+\z/ }, length: { minimum: 4, maximum: 20 }
   validates :body, length: { maximum: 500 }
+  validates :avatar, size: { less_than: 1.megabytes, },
+                      content_type: { in: ['image/png', 'image/jpeg'], spoofing_protection: true }
   validates :x_account, format: { with: /\Ahttps?:\/\/x.com\/[^\n]+\z/ , message: "のURLを入力してください" }, allow_blank: true
   validates :instagram_account, format: { with: /\Ahttps?:\/\/www.instagram.com\/[^\n]+\z/ , message: "のURLを入力してください" }, allow_blank: true
   validates :youtube_account, format: { with: /\Ahttps?:\/\/youtube.com\/[^\n]+\z/ , message: "のURLを入力してください" }, allow_blank: true
-
-  has_many :reviews
-  has_one_attached :avatar
 
   def to_param
     account

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -18,10 +18,10 @@
     </div>
     <div class="field">
       <%= f.label :avatar %><br />
-      <%= f.file_field :avatar, class: "file-input file-input-bordered form-control mb-6 w-full mx-auto mt-2" %>
+      <%= f.file_field :avatar, accept: "image/jpeg,image/png", class: "file-input file-input-bordered form-control mb-6 w-full mx-auto mt-2" %>
       <% if @user.avatar.attached? %>
         <div class="flex flex-col items-center justify-center">
-          <%= image_tag @user.avatar, class: "w-12 rounded-full" %>
+          <%= image_tag @user.avatar, class: "w-12 rounded-full", avatar: @user.reload.avatar %>
           <%=link_to user_attachment_path(@user.id, @user.avatar.id), data: { turbo_method: :delete } do %>
             <i class="fa-regular fa-circle-xmark"></i>
           <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,9 +8,9 @@
     <div class="lg:w-4/5 mx-auto flex flex-wrap items-center justify-center">
       <div class="flex flex-col">
         <% if @user.avatar.attached? %>
-          <div class="bg-white w-[150px] rounded-full mx-10 border-[2px] border-gray-200"><%= image_tag @user.avatar %></div>
+          <%= image_tag @user.avatar, class: "object-cover w-[150px] rounded-full mx-10 border-[2px] border-gray-200" %>
         <% else %>
-          <div class="bg-white w-[150px] rounded-full mx-10 border-[2px] border-gray-200"><%= image_tag 'kkrn_icon_user_1.png' %></div>
+          <%= image_tag 'kkrn_icon_user_1.png', class: "w-[150px] rounded-full mx-10 border-[2px] border-gray-200" %>
         <% end %>
         <div class="mt-5 mx-auto items-center justify-center">
           <%= link_to "https://twitter.com/share?url=#{post_profile_url(@user)}&text=#{@user.name}さんのプロフィール%0a%0a%23インク沼%20%23INKLOG", title: "Xでシェア", class: "btn btn-neutral gap-0 w-[110px]" do %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -44,3 +44,13 @@ ja:
                 one: はjpg形式とpng形式のみ投稿できます
                 other: はjpg形式とpng形式のみ投稿できます
               total_file_size_not_less_than: は3MBまで投稿できます
+        user:
+          attributes:
+            avatar:
+              content_type_invalid:
+                one: はjpg形式とpng形式のみ設定できます
+                other: はjpg形式とpng形式のみ設定できます
+              content_type_spoofed:
+                one: はjpg形式とpng形式のみ設定できます
+                other: はjpg形式とpng形式のみ設定できます
+              total_file_size_not_less_than: は1MBまでの画像が設定できます


### PR DESCRIPTION
- マイページのユーザーアイコンの表示が円形になってなかったのを修正
- avatarのバリデーションを設定。フォームにpngとjpeg形式以外のファイルのアップロードを防ぐ記述と画像がバリデーションに引っ掛かったときにもともと添付されてた画像を表示できるようにする記述を追加

 #157 と一緒にプッシュしたつもりができてなかったので別プルリクになりました。