### PR TITLE
画像をwebp形式にして画像サイズを統一して保存

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -74,13 +74,11 @@ class ReviewsController < ApplicationController
   def process_images(params)
     if params[:images].present?
       params[:images].each do |image|
-        logger.debug "加工前の画像の情報：#{image.tempfile}, #{image.original_filename}, #{image.content_type}"
         image.tempfile = ImageProcessing::MiniMagick.source(image.tempfile).resize_to_fit(700, 700).convert("webp").call
         image.original_filename = "#{File.basename(image.original_filename, ".*")}.webp"
         image.content_type = "image/webp"
-        logger.debug "加工後の画像の情報：#{image.tempfile}, #{image.original_filename}, #{image.content_type}"
       end
-      params
     end
+    params
   end
 end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -8,7 +8,7 @@ class ReviewsController < ApplicationController
   end
 
   def create
-    @review = current_user.reviews.build(review_params)
+    @review = current_user.reviews.build(process_images(review_params))
     product_name = params[:review][:product_name]
     product = Product.find_by(name: product_name)
     @review.product_id = product.id if product
@@ -37,7 +37,7 @@ class ReviewsController < ApplicationController
     product = Product.find_by(name: product_name)
     @review.product_id = product.id if product
 
-    if @review.update(review_params)
+    if @review.update(process_images(review_params))
       flash[:notice] = t('reviews.edit.notice')
       redirect_to review_path(@review)
     else
@@ -69,5 +69,18 @@ class ReviewsController < ApplicationController
 
   def review_params
     params.require(:review).permit(:title, :body, :product_id, :paper, :pen, images: [])
+  end
+
+  def process_images(params)
+    if params[:images].present?
+      params[:images].each do |image|
+        logger.debug "加工前の画像の情報：#{image.tempfile}, #{image.original_filename}, #{image.content_type}"
+        image.tempfile = ImageProcessing::MiniMagick.source(image.tempfile).resize_to_fit(700, 700).convert("webp").call
+        image.original_filename = "#{File.basename(image.original_filename, ".*")}.webp"
+        image.content_type = "image/webp"
+        logger.debug "加工後の画像の情報：#{image.tempfile}, #{image.original_filename}, #{image.content_type}"
+      end
+      params
+    end
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -20,9 +20,15 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # PUT /resource
-  # def update
-  #   super
-  # end
+  def update
+    super
+
+    if params[:user][:avatar].present?
+      process_avatar = ImageProcessing::MiniMagick.source(params[:user][:avatar].tempfile).resize_to_fit(300, 300).convert("webp").call
+      filename_base = File.basename(params[:user][:avatar].original_filename, ".*")
+      @user.avatar.attach(io: process_avatar, filename: "#{filename_base}.webp", content_type: "image/webp")
+    end
+  end
 
   # DELETE /resource
   # def destroy

--- a/app/javascript/controllers/product_controller.js
+++ b/app/javascript/controllers/product_controller.js
@@ -8,7 +8,6 @@ export default class extends Controller {
 
   select(e) {
     const button = e.currentTarget
-    console.log(button.dataset.name)
     this.nameTarget.value = button.dataset.name;
   }
 }

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -9,7 +9,7 @@ class Review < ApplicationRecord
   validates :pen, length: { maximum: 50 }
   validates :images,  total_size: { less_than: 3.megabytes, },
                       limit: { max: 4 },
-                      content_type: { in: ['image/png', 'image/jpeg'], spoofing_protection: true }
+                      content_type: { in: ['image/png', 'image/jpeg', 'image/webp'], spoofing_protection: true }
 
   def self.ransackable_attributes(auth_object = nil)
     ["body", "product_id", "title", "paper", "pen"]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ApplicationRecord
   validates :account, presence: true, uniqueness: true, format: { with: /\A[a-zA-Z0-9]+\z/ }, length: { minimum: 4, maximum: 20 }
   validates :body, length: { maximum: 500 }
   validates :avatar, size: { less_than: 1.megabytes, },
-                      content_type: { in: ['image/png', 'image/jpeg'], spoofing_protection: true }
+                      content_type: { in: ['image/png', 'image/jpeg', 'image/webp'], spoofing_protection: true }
   validates :x_account, format: { with: /\Ahttps?:\/\/x.com\/[^\n]+\z/ , message: "のURLを入力してください" }, allow_blank: true
   validates :instagram_account, format: { with: /\Ahttps?:\/\/www.instagram.com\/[^\n]+\z/ , message: "のURLを入力してください" }, allow_blank: true
   validates :youtube_account, format: { with: /\Ahttps?:\/\/youtube.com\/[^\n]+\z/ , message: "のURLを入力してください" }, allow_blank: true

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -12,10 +12,10 @@
         <%= f.label :images, class: "px-3" %><%= t('reviews.form.number_of_images') %>
         <%= f.file_field :images, accept: "image/jpeg,image/png", class: "file-input file-input-bordered w-full mx-auto", multiple: true, include_hidden: false %>
         <% if @review.images.attached? %>
-          <div class="flex mx-2 mt-2 gap-[24px]">
+          <div class="flex mx-2 mt-2 gap-[24px] items-center justify-center">
             <% @review.images.each do |image| %>
               <div class ="flex flex-col items-center justify-center">
-                <%= image_tag image, class: "lg:w-[80px] w-full lg:h-[80px] h-64 object-cover object-center" %>
+                <%= image_tag image, class: "lg:w-[80px] w-full lg:h-[80px] h-64 object-fill object-center" %>
                 <%=link_to review_attachment_path(@review.id, image.id), data: { turbo_method: :delete } do %>
                   <i class="fa-regular fa-circle-xmark"></i>
                 <% end %>

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -24,13 +24,11 @@
   <div class="card-body gap-0 flex-shrink-0 w-[340px] p-4">
     <div class="card-title overflow-hidden mb-1 justify-between">
       <span class="w-3/4 text-[24px] font-bold text-ellipsis line-clamp-1"><%= review.title %></span>
-      <div class="w-8 rounded-full border-[2px] border-gray-200">
-        <% if review.user.avatar.attached? %>
-          <%= image_tag review.user.avatar %>
-        <% else %>
-          <%= image_tag 'kkrn_icon_user_1.png' %>
-        <% end %>
-      </div>
+      <% if review.user.avatar.attached? %>
+        <%= image_tag review.user.avatar, class: "w-8 rounded-full border-[2px] border-gray-200" %>
+      <% else %>
+        <%= image_tag 'kkrn_icon_user_1.png', class: "w-8 rounded-full border-[2px] border-gray-200" %>
+      <% end %>
     </div>
     <div class="text-sm"><%= review.product.name %></div>
     <div class="text-sm"><%= review.product.brand.name %></div>

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -1,9 +1,9 @@
 <div class="card card-side m-4 shadow" id="review-<%= review.id %>">
   <div class="px-4 py-4 relative">
     <% if review.images.attached? %>
-      <%= image_tag review.images[0].variant(resize_to_limit: [170, 170]).processed, class: "h-[170px] w-[170px] rounded-lg" %>
+      <%= image_tag review.images[0], class: "h-[170px] w-[170px] rounded-lg" %>
     <% else %>
-      <%= image_tag 'kkrn_icon_shashin_3.png', class: "h-[170px] w-[170px] rounded-lg" %>
+      <%= image_tag 'kkrn_icon_shashin_3.png', class: "h-[170px] w-[170px] rounded-lg object-cover" %>
     <% end %>
     <% if review.images.count > 1 %>
       <div class=" bg-black bg-opacity-50 absolute top-4 right-4 rounded-tr-lg rounded-bl-lg px-2">

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -15,7 +15,7 @@
           <div thumbsSlider="" class="swiper mySwiper lg:w-[350px] mt-1">
             <div class="swiper-wrapper">
               <% @review.images.each do |image| %>
-                <%= image_tag image.variant(resize_to_limit: [80, 80]).processed, class: "lg:w-[80px] w-full lg:h-[80px] h-64 object-cover object-center rounded swiper-slide" %>
+                <%= image_tag image, class: "lg:w-[80px] w-full lg:h-[80px] h-64 object-fill object-center rounded swiper-slide" %>
               <% end %>
             </div>
           </div>

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -34,13 +34,11 @@
         <h1 class="text-gray-900 text-3xl title-font font-medium mb-1"><%= @review.title %></h1>
         <div class="flex mb-4">
           <%= link_to user_path(@review.user), class: "flex items-center gap-2" do %>
-            <div class="w-10 rounded-full border-[2px] border-gray-200">
-              <% if @review.user.avatar.attached? %>
-                <%= image_tag @review.user.avatar %>
-              <% else %>
-                <%= image_tag 'kkrn_icon_user_1.png' %>
-              <% end %>
-            </div>
+            <% if @review.user.avatar.attached? %>
+              <%= image_tag @review.user.avatar, class: "w-10 rounded-full border-[2px] border-gray-200" %>
+            <% else %>
+              <%= image_tag 'kkrn_icon_user_1.png', class: "w-10 rounded-full border-[2px] border-gray-200" %>
+            <% end %>
             <p><%= @review.user.name %></p>
           <% end %>
           <div class="flex ml-auto items-center justify-center text-[#959595]"><%= l(@review.created_at) %></div>


### PR DESCRIPTION
# 実施タスク
closes #155 
投稿される画像をリサイズして大きさを統一し、ファイル形式もwebp形式で保存されるように変更。
ストレージの容量削減を目指します。

# 実施内容
- レビュー投稿時に画像をリサイズしてwebp形式に変換してからアップロードするようにしました。
- ユーザーアイコン設定時にも画像をリサイズしてwebp形式に変換してからアップロードするようにしました。
- userモデルとreviewモデルの画像のバリデーションで、webp形式の投稿を許可するように変更しました。
- 変更に伴い、ストレージ容量を削減するためと画像の表示速度向上のため、variant画像を生成して表示させていた部分をCSSで画像サイズを変えて表示するように変更しました。

# 備考
- app/javascript/controllers/product_controller.jsにデバッグ用のconsole.logが残ったままだったので削除しました。
- レビューのカードと詳細画面のユーザーアイコンの表示が円形になってなかったので修正しました。
- 小さいサムネイル画像ががびがびになってしまうので、カルーセルのサムネイルとeditの添付画像のCSSを`object-cover`から`object-fill`に変更しています。