### PR TITLE
インク登録時にバリデーションエラーが発生するとエラー画面に遷移していた問題を修正

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -21,7 +21,7 @@ class ProductsController < ApplicationController
                 if brand.present?
                   @product.brand_id = brand.id
                 else
-                  raise ActiveRecord::Rollback, "メーカーが登録されていません"
+                  raise ActiveRecord::Rollback, t('brand.new.alert')
                 end
 
                 if @product.save

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -17,7 +17,7 @@ class ProductsController < ApplicationController
     @product = Product.new(product_params)
     result = ActiveRecord::Base.transaction do
                 brand_name = params[:product][:brand_name]
-                brand = Brand.find_or_create_by!(name: brand_name)
+                brand = Brand.find_or_create_by(name: brand_name)
                 if brand.present?
                   @product.brand_id = brand.id
                 else

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -10,9 +10,7 @@ class ReviewsController < ApplicationController
   def create
     @review = current_user.reviews.build(process_images(review_params))
     result = ActiveRecord::Base.transaction do
-                product_name = params[:review][:product_name]
-                product = Product.find_by(name: product_name)
-                @review.product_id = product.id if product
+                set_product
 
                 if @review.save
                   flash[:notice] = t('reviews.new.notice')
@@ -39,9 +37,7 @@ class ReviewsController < ApplicationController
   def update
     @review = current_user.reviews.find(params[:id])
     result = ActiveRecord::Base.transaction do
-                product_name = params[:review][:product_name]
-                product = Product.find_by(name: product_name)
-                @review.product_id = product.id if product
+                set_product
 
                 if @review.update(process_images(review_params))
                   flash[:notice] = t('reviews.edit.notice')
@@ -92,5 +88,11 @@ class ReviewsController < ApplicationController
       end
     end
     params
+  end
+
+  def set_product
+    product_name = params[:review][:product_name]
+    product = Product.find_by(name: product_name)
+    @review.product_id = product.id if product
   end
 end

--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -1,5 +1,5 @@
 class Brand < ApplicationRecord
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
   validates :official_url, format: { with: /\Ahttps?:\/\/[^\n]+\z/, message: "不正なURLです" }, allow_blank: true
   validates :official_shopping_url, format: { with: /\Ahttps?:\/\/[^\n]+\z/, message: "不正なURLです" }, allow_blank: true
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,5 +1,6 @@
 class Product < ApplicationRecord
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
+  validates :category_id, presence: true
 
   belongs_to :brand
   has_many :reviews

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: product, class: "w-full max-w-lg") do |f| %>
+<%= form_with(model: product, html: { data: { turbo: turbo_frame_request? } }, class: "w-full max-w-lg") do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
   <div class="flex flex-wrap -mx-3 mb-4">
     <div class="w-full px-3">

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -28,6 +28,8 @@ ja:
       product:
         name: インクの名前
         brand_name: メーカー名
+        category_id: 色系統
+        brand: メーカー名
     errors:
       models:
         review:
@@ -54,3 +56,7 @@ ja:
                 one: はjpg形式とpng形式のみ設定できます
                 other: はjpg形式とpng形式のみ設定できます
               total_file_size_not_less_than: は1MBまでの画像が設定できます
+        product:
+          attributes:
+            category_id:
+              blank: を選択してください

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,11 +1,11 @@
 ja:
   helpers:
     submit:
-      reviews:
+      review:
         create: 投稿する
         submit: 保存する
         update: 編集する
-      products:
+      product:
         create: 登録する
         submit: 保存する
         update: 更新する
@@ -95,3 +95,6 @@ ja:
   category:
     select:
       include_blank: 色系統を選択
+  brand:
+    new:
+      alert: メーカーの登録に失敗しました


### PR DESCRIPTION
# 実施タスク
インク登録時にバリデーションエラーが発生すると、フォーム画面にとどまってバリデーションエラー表示が出るのではなく、`/product`に遷移してエラー画面が表示されるようになっていたので修正しました。
一緒にI18n対応もしています。

# 実施内容
- app/views/products/_form.html.erbのform_withに`data-turbo=true`になる記述を追加してバリデーションエラー時に遷移しないようにしました。
- app/controllers/products_controller.rbの`find_or_create_by!`だと例外発生して別ページに遷移してしまうので、`find_or_create_by`に変更しています（トランザクション内の処理なのでこっちでも問題ないと思います）。
- I18n対応できてなかったのでやりました。

# 備考
- app/controllers/reviews_controller.rbのprduct_idをセットする記述をメソッド化しておきました（同じ記述がcreateとupdateで行われていたので）。