### PR TITLE
複数キーワードで検索できるようにする

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -41,9 +41,13 @@ class ProductsController < ApplicationController
   end
 
   def search
-    @q = params[:q].split(/[\s　]/)
+    if params[:q].blank?
+      @q = params[:q]
+    else
+      @q = params[:q].split(/[\s　]/)
+    end
     @c = params[:c]
-    @products = Product.ransack(name_or_brand_name_cont_all: @q, category_id_eq: @c).result(distinct: true).
+    @products = Product.ransack(name_or_brand_name_cont_any: @q, category_id_eq: @c).result(distinct: true).
                 includes(:brand).order(:created_at, :id)
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,7 +1,11 @@
 class ProductsController < ApplicationController
   def index
-    @q = params[:q]
-    @products = Product.ransack(name_or_brand_name_cont: @q).result(distinct: true).order(:created_at, :id)
+    if params[:q].blank?
+      @q = params[:q]
+    else
+      @q = params[:q].split(/[\s　]/)
+    end
+    @products = Product.ransack(name_or_brand_name_cont_all: @q).result(distinct: true).order(:created_at, :id)
   end
 
   def show
@@ -37,9 +41,9 @@ class ProductsController < ApplicationController
   end
 
   def search
-    @q = params[:q]
+    @q = params[:q].split(/[\s　]/)
     @c = params[:c]
-    @products = Product.ransack(name_or_brand_name_cont: @q, category_id_eq: @c).result(distinct: true).
+    @products = Product.ransack(name_or_brand_name_cont_all: @q, category_id_eq: @c).result(distinct: true).
                 includes(:brand).order(:created_at, :id)
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -7,7 +7,6 @@ class ProductsController < ApplicationController
       @q = params[:q].split(/[\s　]/)
       @grouping_word = @q.each_with_index.reduce({}){|hash, (word, i)| hash.merge(i.to_s => { name_or_brand_name_cont: word })}
     end
-    logger.debug "#{@grouping_word}"
     @products = Product.ransack({ combinator: "and", groupings: @grouping_word }).
                 result(distinct: true).includes(:brand).order(created_at: "DESC")
   end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -67,9 +67,9 @@ class ReviewsController < ApplicationController
   end
 
   def search
-    @q = params[:q]
+    @q = params[:q].split(/[\s　]/)
     @c = params[:c]
-    @reviews = Review.ransack(title_or_body_or_product_name_or_paper_or_pen_or_product_brand_name_cont: @q, product_category_id_eq: @c).
+    @reviews = Review.ransack(title_or_body_or_product_name_or_paper_or_pen_or_product_brand_name_cont_all: @q, product_category_id_eq: @c).
                 result(distinct: true).includes(:user, product: :brand).order(:created_at, :id)
   end
 

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -67,10 +67,14 @@ class ReviewsController < ApplicationController
   end
 
   def search
-    @q = params[:q].split(/[\s　]/)
+    if params[:q].blank?
+      @q = params[:q]
+    else
+      @q = params[:q].split(/[\s　]/)
+    end
     @c = params[:c]
-    @reviews = Review.ransack(title_or_body_or_product_name_or_paper_or_pen_or_product_brand_name_cont_all: @q, product_category_id_eq: @c).
-                result(distinct: true).includes(:user, product: :brand).order(:created_at, :id)
+    @reviews = Review.ransack(title_or_body_or_product_name_or_paper_or_pen_or_product_brand_name_cont_any: @q, product_category_id_eq: @c).
+                result(distinct: true).includes(:user, product: :brand).order(created_at: "DESC")
   end
 
   private

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -73,7 +73,9 @@ class ReviewsController < ApplicationController
       @q = params[:q].split(/[\s　]/)
     end
     @c = params[:c]
-    @reviews = Review.ransack(title_or_body_or_product_name_or_paper_or_pen_or_product_brand_name_cont_any: @q, product_category_id_eq: @c).
+    @grouping_word = @q.each_with_index.reduce({}){|hash, (word, i)| hash.merge(i.to_s => { review_search_cont: word })}
+    @grouping_word["Category_refine"] = { product_category_id_eq: @c }
+    @reviews = Review.ransack({ combinator: "and", groupings: @grouping_word }).
                 result(distinct: true).includes(:user, product: :brand).order(created_at: "DESC")
   end
 

--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -8,4 +8,8 @@ class Brand < ApplicationRecord
   def self.ransackable_attributes(auth_object = nil)
     ["name"]
   end
+
+  def self.ransackable_associations(auth_object = nil)
+    ["products"]
+    end
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -13,6 +13,8 @@ class Review < ApplicationRecord
                       limit: { max: 4 },
                       content_type: { in: ['image/png', 'image/jpeg', 'image/webp'], spoofing_protection: true }
 
+  ransack_alias :review_search, :title_or_body_or_product_name_or_paper_or_pen_or_product_brand_name
+
   def self.ransackable_attributes(auth_object = nil)
     ["body", "product_id", "title", "paper", "pen"]
   end

--- a/app/views/shared/_search_tab.html.erb
+++ b/app/views/shared/_search_tab.html.erb
@@ -1,13 +1,25 @@
 
 <p class="text-center">
   <% if @q.present? && @c.present? %>
-    <%= Category.find(@c).color %><%= t('search.product')%> <%= @q %>
+    <%= Category.find(@c).color %><%= t('search.product')%>
+    <% @q.each do |word| %>
+      <%= word %>
+    <% end %>
   <% elsif @q.present? %>
-    <%= @q %>
+    <% @q.each do |word| %>
+      <%= word %>
+    <% end %>
   <% elsif @c.present? %>
     <%= Category.find(@c).color %><%= t('search.product')%>
   <% end %>
   <%= t('search.result')%>
+</p>
+<p class="text-center">
+  <% if request.path.include?("reviews") %>
+    <%= @reviews.count %>件
+  <% else %>
+    <%= @products.count %>件
+  <% end %>
 </p>
 <div class="font-medium text-center text-gray-500 border-b border-gray-200 dark:text-gray-400 dark:border-gray-700 w-1/2 mx-auto mb-5">
   <ul class="flex flex-wrap justify-center items-center -mb-px">


### PR DESCRIPTION
# 実施タスク
closes #107 
フリーワード検索で、複数ワードで検索できるようにする（AND検索）

# 実施内容
- 受け取った`params[:q]`を半角全角スペース区切りで配列にする
- ransackの条件グループを使って、各単語で指定のカラムを検索してすべての検索ワードがどこかのカラムに入っているもののみを結果として渡すようにした。
  発行されるクエリ↓
  [![Image from Gyazo](https://i.gyazo.com/8cb67fe9a2b22d3655def53798dcc6fd.png)](https://gyazo.com/8cb67fe9a2b22d3655def53798dcc6fd)
  検索結果
  [![Image from Gyazo](https://i.gyazo.com/721be84b373e5fc0d040b0bf913a9e0a.png)](https://gyazo.com/721be84b373e5fc0d040b0bf913a9e0a)

# 備考
ransackのシンプルモードの述語では期待通りのクエリにならなかったので条件グループを使っています。
  シンプルモードで複数カラムを指定してAND検索をやるときは`title_or_body_or_product_name_or_paper_or_pen_or_product_brand_name_cont_all`というような記述になると思いますが、この場合に発行されるクエリは以下のように、各カラムに入力された検索ワードがすべて入っているものを探すか、
```bash
SELECT COUNT(*) 
FROM (SELECT DISTINCT "reviews".* FROM "reviews" LEFT OUTER JOIN "products" ON "products"."id" = "reviews"."product_id" LEFT OUTER JOIN "brands" ON "brands"."id" = "products"."brand_id" 
WHERE (((((("reviews"."title" ILIKE '%webp%' AND "reviews"."title" ILIKE '%青%')
 OR ("reviews"."body" ILIKE '%webp%' AND "reviews"."body" ILIKE '%青%'))
  OR ("products"."name" ILIKE '%webp%' AND "products"."name" ILIKE '%青%'))
   OR ("reviews"."paper" ILIKE '%webp%' AND "reviews"."paper" ILIKE '%青%'))
    OR ("reviews"."pen" ILIKE '%webp%' AND "reviews"."pen" ILIKE '%青%'))
     OR ("brands"."name" ILIKE '%webp%' AND "brands"."name" ILIKE '%青%'))
      ORDER BY "reviews"."created_at" DESC) subquery_for_count

SELECT DISTINCT "reviews".* FROM "reviews" LEFT OUTER JOIN "products" ON "products"."id" = "reviews"."product_id" LEFT OUTER JOIN "brands" ON "brands"."id" = "products"."brand_id"
 WHERE (((((("reviews"."title" ILIKE '%webp%' AND "reviews"."title" ILIKE '%青%')
  OR ("reviews"."body" ILIKE '%webp%' AND "reviews"."body" ILIKE '%青%'))
   OR ("products"."name" ILIKE '%webp%' AND "products"."name" ILIKE '%青%'))
    OR ("reviews"."paper" ILIKE '%webp%' AND "reviews"."paper" ILIKE '%青%'))
     OR ("reviews"."pen" ILIKE '%webp%' AND "reviews"."pen" ILIKE '%青%'))
      OR ("brands"."name" ILIKE '%webp%' AND "brands"."name" ILIKE '%青%'))
       ORDER BY "reviews"."created_at" DESC
```
あるいは`title_and_body_and_product_name_and_paper_and_pen_and_product_brand_name_cont_all`として、すべてのカラムにすべての検索ワードが入っているものを探す、という挙動となります（上のクエリのWHERE句のORがANDになります）。
OR検索なら検索ワードがどれか一つが入っていれば検索結果にでてきますが、検索ワードが増えるごとに検索結果も増えてしまいます。
条件グループだと、各単語ごとにグループを作ってANDで結果をまとめることができます。
```ruby
q = ["たけのこ", "きのこ"]
grouping = q.each_with_index.reduce({}){|hash, (word, i)| hash.merge(i.to_s => { review_search_cont: word })}
#=> {"0"=>{:review_search_cont=>"たけのこ"}, "1"=>{:review_search_cont=>"きのこ"}}
# このコードを下記のようなransackのコードに渡す
# @reviews = Review.ransack({ combinator: "and", groupings: @grouping_word }).result(distinct: true).includes(:user, product: :brand).order(created_at: "DESC")
```
これで`combinator: "and"`を指定して検索をすると、下記ようなのクエリが発行され、すべての検索ワードがいずれかのカラム入っているものが結果に出てきます。
[![Image from Gyazo](https://i.gyazo.com/8cb67fe9a2b22d3655def53798dcc6fd.png)](https://gyazo.com/8cb67fe9a2b22d3655def53798dcc6fd)

参考文献：
https://nekorails.hatenablog.com/entry/2017/05/31/173925#038-ggroupings---%E6%9D%A1%E4%BB%B6%E3%82%B0%E3%83%AB%E3%83%BC%E3%83%97
https://qiita.com/Jackson123/items/2c3c73da6679db6f53c7