### PR TITLE
カテゴリのみを選択していた時に、NoMethodErrorが出ていたのを修正

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,7 +2,7 @@ class ProductsController < ApplicationController
   def index
     if params[:q].blank?
       @q = params[:q]
-      @grouping_word = @q
+      @grouping_word = {"0"=>{name_or_brand_name_cont: @q}}
     else
       @q = params[:q].split(/[\s　]/)
       @grouping_word = @q.each_with_index.reduce({}){|hash, (word, i)| hash.merge(i.to_s => { name_or_brand_name_cont: word })}
@@ -46,11 +46,12 @@ class ProductsController < ApplicationController
   def search
     if params[:q].blank?
       @q = params[:q]
+      @grouping_word = {"0"=>{name_or_brand_name_cont: @q}}
     else
       @q = params[:q].split(/[\s　]/)
+      @grouping_word = @q.each_with_index.reduce({}){|hash, (word, i)| hash.merge(i.to_s => { name_or_brand_name_cont: word })}
     end
     @c = params[:c]
-    @grouping_word = @q.each_with_index.reduce({}){|hash, (word, i)| hash.merge(i.to_s => { name_or_brand_name_cont: word })}
     @grouping_word["Category_refine"] = { category_id_eq: @c }
     @products = Product.ransack({ combinator: "and", groupings: @grouping_word }).
                 result(distinct: true).includes(:brand).order(created_at: "DESC")

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -69,11 +69,12 @@ class ReviewsController < ApplicationController
   def search
     if params[:q].blank?
       @q = params[:q]
+      @grouping_word = {"0"=>{review_search_cont: @q}}
     else
       @q = params[:q].split(/[\s　]/)
+      @grouping_word = @q.each_with_index.reduce({}){|hash, (word, i)| hash.merge(i.to_s => { review_search_cont: word })}
     end
     @c = params[:c]
-    @grouping_word = @q.each_with_index.reduce({}){|hash, (word, i)| hash.merge(i.to_s => { review_search_cont: word })}
     @grouping_word["Category_refine"] = { product_category_id_eq: @c }
     @reviews = Review.ransack({ combinator: "and", groupings: @grouping_word }).
                 result(distinct: true).includes(:user, product: :brand).order(created_at: "DESC")


### PR DESCRIPTION
# 実施タスク
カテゴリのみを選択して検索したときに、NoMethodError (undefined method `each_with_index` for an instance of String)が出ていたのを修正しました。

# 実施内容
- app/controllers/reviews_controller.rbとapp/controllers/products_controller.rbの`params[:q]`が空だった時の処理に条件グループが一つだけの@grouping_wordを設定するようにしました。

# 備考
`params[:q]`が空だと`each_with_index`がエラーになってしまうので、`params[:q]`が空の時は`each_with_index`を使わずに条件グループを一つだけ設定するような形で対応しました。